### PR TITLE
docker logs で色がつくように

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "8080:8080"
     depends_on:
       - database
+    tty: true
   database:
     image: mysql:5.7
     volumes:


### PR DESCRIPTION
- `tty: true` を追加することで docker logs で出力されるログに色がつくようにした